### PR TITLE
Update android gradle plugin to 1.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.android.tools.build:gradle:1.0.0'
+  compile 'com.android.tools.build:gradle:1.2.3'
   compile 'com.squareup.wire:wire-compiler:1.8.0'
 }
 


### PR DESCRIPTION
Figured I'd submit this as well, though I don't know what your policy here is. _Technically speaking_, this shouldn't be necessary unless the Android plugin didn't follow SemVer or we wanted some functionality only available in a newer release. On the other hand, it's always nice to be up-to-date.

/cc @JakeWharton
