### PR TITLE
Kotlin plugin's compile task should depend on Wire generation

### DIFF
--- a/src/main/groovy/com/squareup/wire/gradle/WirePlugin.groovy
+++ b/src/main/groovy/com/squareup/wire/gradle/WirePlugin.groovy
@@ -60,6 +60,8 @@ class WirePlugin implements Plugin<Project> {
           (JavaCompile) project.tasks.getByName("compile${taskName.capitalize()}Java")
       compileTask.source += project.fileTree(task.outputDir)
       compileTask.dependsOn(task)
+      def kotlinCompileTask = project.tasks.getByName("compile${taskName.capitalize()}Kotlin")
+      kotlinCompileTask.dependsOn(task)
     }
   }
 


### PR DESCRIPTION
Naively fixes #7 
